### PR TITLE
Dynamic rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,15 @@ import logging
 from remote_gym import create_remote_environment_server
 
 server = create_remote_environment_server(
-   default_args={
-      "entrypoint": "exploration/remote_environment_entrypoint.py",
-   },
-   # IP of the machine hosting the remote environment; can also be 0.0.0.0
-   url=YOUR_SERVER_IP,
-   # port the remote environment should use on the hosting machine
-   port=PORT_FOR_REMOTE_ENVIRONMENT_TO_LISTEN,
-   # not using a tuple but setting this completely to None is also possible in case only a local connection is required
-   server_credentials_paths=("path/to/server.pem", "path/to/server-key.pem", "optional/path/to/ca.pem"),
-   # can be set to True in case rendering is required, but significantly increases exchanged data and slows down interaction
-   enable_rendering=False,
+    default_args={
+        "entrypoint": "exploration/remote_environment_entrypoint.py",
+    },
+    # IP of the machine hosting the remote environment; can also be 0.0.0.0
+    url=YOUR_SERVER_IP,
+    # port the remote environment should use on the hosting machine
+    port=PORT_FOR_REMOTE_ENVIRONMENT_TO_LISTEN,
+    # not using a tuple but setting this completely to None is also possible in case only a local connection is required
+    server_credentials_paths=("path/to/server.pem", "path/to/server-key.pem", "optional/path/to/ca.pem"),
 )
 
 try:
@@ -75,11 +73,18 @@ done = False
 episode_reward = 0
 environment.reset()
 while not done:
-  action = environment.action_space.sample()
-  _observation, reward, terminated, truncated, _info = environment.step(action)
-  episode_reward += reward
-  done = terminated or truncated
+    action = environment.action_space.sample()
+    _observation, reward, terminated, truncated, _info = environment.step(action)
+    episode_reward += reward
+    done = terminated or truncated
 ```
+
+### Rendering
+
+To preserve server resources and prevent network slowdowns, it is recommended to only enable rendering if required.
+Renderings are automatically transferred from the remote management server to the RemoteEnvironment together with the
+observation if the `render_mode` of the hosted environment is `rgb_array`.
+The `render_mode` of the hosted environment should be controlled by the `entrypoint_kwargs` passed to the entrypoint.
 
 ## Set-Up
 

--- a/exploration/start_remote_environment.py
+++ b/exploration/start_remote_environment.py
@@ -29,14 +29,6 @@ if __name__ == "__main__":
         default=56789,
     )
     parser.add_argument(
-        "-r",
-        "--enable_rendering",
-        action="store_true",
-        help="Flag for enabling rendering on the remote environment. "
-        "If set to True, make sure that the passed environment has its .render_mode attribute set to 'rgb_array'.",
-        default=False,
-    )
-    parser.add_argument(
         "--server_certificate",
         type=str,
         help="Path to the self-signed server certificate (for TLS authentication)",  # server.pem
@@ -59,7 +51,6 @@ if __name__ == "__main__":
     url = args.url
     port = args.port
     server_credentials_paths = (args.server_certificate, args.server_private_key, args.root_certificate)
-    enable_rendering = args.enable_rendering
 
     server = create_remote_environment_server(
         default_args={
@@ -75,7 +66,6 @@ if __name__ == "__main__":
         url=url,
         port=port,
         server_credentials_paths=server_credentials_paths if any(server_credentials_paths) else None,
-        enable_rendering=enable_rendering,
     )
 
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -374,13 +374,13 @@ test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit",
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.63.2"
+version = "1.65.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "googleapis-common-protos-1.63.2.tar.gz", hash = "sha256:27c5abdffc4911f28101e635de1533fb4cfd2c37fbaa9174587c799fac90aa87"},
-    {file = "googleapis_common_protos-1.63.2-py2.py3-none-any.whl", hash = "sha256:27a2499c7e8aff199665b22741997e485eccc8645aa9176c7c988e6fae507945"},
+    {file = "googleapis_common_protos-1.65.0-py2.py3-none-any.whl", hash = "sha256:2972e6c496f435b92590fd54045060867f3fe9be2c82ab148fc8885035479a63"},
+    {file = "googleapis_common_protos-1.65.0.tar.gz", hash = "sha256:334a29d07cddc3aa01dee4988f9afd9b2916ee2ff49d6b757155dc0d197852c0"},
 ]
 
 [package.dependencies]
@@ -789,6 +789,35 @@ files = [
 ]
 
 [[package]]
+name = "psutil"
+version = "6.0.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:a9a3dbfb4de4f18174528d87cc352d1f788b7496991cca33c6996f40c9e3c92c"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6ec7588fb3ddaec7344a825afe298db83fe01bfaaab39155fa84cf1c0d6b13c3"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:1e7c870afcb7d91fdea2b37c24aeb08f98b6d67257a5cb0a8bc3ac68d0f1a68c"},
+    {file = "psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35"},
+    {file = "psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1"},
+    {file = "psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e8d0054fc88153ca0544f5c4d554d42e33df2e009c4ff42284ac9ebdef4132"},
+    {file = "psutil-6.0.0-cp36-cp36m-win32.whl", hash = "sha256:fc8c9510cde0146432bbdb433322861ee8c3efbf8589865c8bf8d21cb30c4d14"},
+    {file = "psutil-6.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:34859b8d8f423b86e4385ff3665d3f4d94be3cdf48221fbe476e883514fdb71c"},
+    {file = "psutil-6.0.0-cp37-abi3-win32.whl", hash = "sha256:a495580d6bae27291324fe60cea0b5a7c23fa36a7cd35035a16d93bdcf076b9d"},
+    {file = "psutil-6.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:33ea5e1c975250a720b3a6609c490db40dae5d83a4eb315170c4fe0d8b1f34b3"},
+    {file = "psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0"},
+    {file = "psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
 name = "pygame"
 version = "2.1.0"
 description = "Python Game Development"
@@ -1102,13 +1131,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.26.3"
+version = "20.26.5"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
-    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
+    {file = "virtualenv-20.26.5-py3-none-any.whl", hash = "sha256:4f3ac17b81fba3ce3bd6f4ead2749a72da5929c01774948e243db9ba41df4ff6"},
+    {file = "virtualenv-20.26.5.tar.gz", hash = "sha256:ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4"},
 ]
 
 [package.dependencies]
@@ -1139,4 +1168,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.11"
-content-hash = "498620d9682634ca0e27457c4fcfd1d06ddf91d3dcd55e6fbbe66a36e407512c"
+content-hash = "a679369516eee0f4a710f11e05f4d00a56d787174e722137fbd553f93a9c4bb4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dm-env-rpc = "^1.1.6"
 opencv-python = "^4.9.0.80"
 gitpython = "^3.1.43"
 fasteners = "^0.19"
+psutil = "^6.0.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.2"

--- a/src/remote_gym/remote_environment.py
+++ b/src/remote_gym/remote_environment.py
@@ -35,10 +35,6 @@ class RemoteArgs(TypedDict):
         The server may add additional fields (such as `end_id`).
         To remain forward-compatible, use **kwargs to dismiss unused fields!
 
-        It is recommended to only enable rendering if required to preserve server resources.
-        Rendering is send together with the observation if the environments render mode is set to "rgb_array"
-        One can for example pass a kwarg "enable_rendering" to let the entrypoint know that rendering should be enabled.
-
 
     Example:
         ```py
@@ -129,7 +125,6 @@ class RemoteEnvironment(Env):
                 - “rgb_array” (default): return a single frame representing the current state of the environment.
                     A frame is a np.ndarray with shape (x, y, 3) representing RGB values for an x-by-y pixel image.
                 - “human”: .render displays the current frame on the current display using cv2
-                NOTE: Rendering is only supported if the remote environment was initiated with `enable_rendering=True`
         """
 
         def convert_to_space(spec: specs.Array) -> Space:

--- a/src/remote_gym/remote_environment.py
+++ b/src/remote_gym/remote_environment.py
@@ -32,7 +32,7 @@ class RemoteArgs(TypedDict):
         * `env_id` is a unique identifier for the environment, used for non-sharable resources.
         * `kwargs` are any additional kwargs, including entrypoint_kwargs passed from the RemoteEnvironment
 
-        The server may add additional fields (such as `end_id`).
+        The server may add additional fields (such as `env_id`).
         To remain forward-compatible, use **kwargs to dismiss unused fields!
 
 

--- a/src/remote_gym/remote_environment.py
+++ b/src/remote_gym/remote_environment.py
@@ -26,15 +26,18 @@ class RemoteArgs(TypedDict):
     Note:
         The entrypoint file must define a function `create_environment`:
         ```py
-        def create_environment(enable_rendering: bool, env_id: int, **kwargs) -> gym.Env:
+        def create_environment(env_id: int, **kwargs) -> gym.Env:
             return gym.make(...)
         ```
-        * `enable_rendering` is whether the env should render.
         * `env_id` is a unique identifier for the environment, used for non-sharable resources.
         * `kwargs` are any additional kwargs, including entrypoint_kwargs passed from the RemoteEnvironment
 
-        The server may add additional fields (such as `enable_rendering` and `end_id`).
+        The server may add additional fields (such as `end_id`).
         To remain forward-compatible, use **kwargs to dismiss unused fields!
+
+        It is recommended to only enable rendering if required to preserve server resources.
+        Rendering is send together with the observation if the environments render mode is set to "rgb_array"
+        One can for example pass a kwarg "enable_rendering" to let the entrypoint know that rendering should be enabled.
 
 
     Example:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -13,7 +13,6 @@ def test_readme():
         },
         url="localhost",
         port=12345,
-        enable_rendering=False,
     )
 
     # Start environment


### PR DESCRIPTION
By pulling rendering into the kwargs it becomes an issue to be resolved by the respective environment.
The server then only checks whether rendering is enabled (rgb_array mode active).
Since the expensive part is often rendering and not the bandwidth, I see no issue in always sending when present. If rendering is not required, it should be disabled in the env.
Edge case is switching rendering mid-loop, which is simply not supported. It's odd anyways.